### PR TITLE
Set project.dir.src to point to {out}/src #issue 89

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -55,19 +55,10 @@
     <log message="Assigning project directories and files to phing properties...${line.separator}" level="debug"/>
       <property name="project.dir.dist" value="${phing.dir.build_ads}"/>
       <property name="project.dir.profile" value="${project.dir.dist}"/>
+      <property name="project.dir.src" value="${project.dir.profile}/src"/>
       <!-- <property name="project.dir.taxonomies" value="${project.dir.src}/sites/all/modules/ads/ads_features"/> -->
 
-      <if>
-        <isset property="out"/>
-        <then>
-          <property name="project.dir.src" value="${out}/src"/>
-        </then>
-        <else>
-          <property name="project.dir.src" value="${project.dir.profile}/src"/>
-        </else>
-      </if>
-
-    <log message="Building ADS into &quot;${project.dir.src}&quot;" level="verbose"/>
+      <log message="Building ADS into &quot;${project.dir.src}&quot;" level="verbose"/>
 
       <!-- <property name="project.dir.src.ads_features" value="${project.dir.src}/sites/all/modules/ads/ads_features"/> -->
       <property name="project.file.makefile" value="build-ads.make"/>
@@ -184,6 +175,20 @@
           <fail message="Drupal build failed, directory &quot;${project.dir.src}&quot; does not exist" />
         </then>
       </if>
+
+      <if>
+        <isset property="out"/>
+        <then>
+          <log message="Moving Drupal build folder &quot;${project.dir.src}&quot; to destination &quot;${out}&quot;" level="debug" />
+          <move todir="${out}">
+            <fileset dir="${project.dir.src}">
+              <include name="**/*" />
+            </fileset>
+          </move>
+        </then>
+      </if>
+
+
 
       <!-- Done -->
       <log message="" level="info" />

--- a/build.xml
+++ b/build.xml
@@ -60,7 +60,7 @@
       <if>
         <isset property="out"/>
         <then>
-          <property name="project.dir.src" value="${out}"/>
+          <property name="project.dir.src" value="${out}/src"/>
         </then>
         <else>
           <property name="project.dir.src" value="${project.dir.profile}/src"/>


### PR DESCRIPTION
Even if this commit is merged, `drush dl --dev` will download from `http://updates.drupal.org/release-history/ads/7.x` and try and build a version without this commit and will fail again. So this commit needs to be in whatever version drush downloads. One way might be to merge this off master and use `drush dl ads --dev --package-handler=git_drupalorg` and then `cd ads && git checkout -b feature/build-in-existing-path` and then finally, `phing -D out=..` should work